### PR TITLE
Cms typed performer extraction fix

### DIFF
--- a/lib/parser/cms/sections/claims.js
+++ b/lib/parser/cms/sections/claims.js
@@ -292,7 +292,7 @@ function extrapolatePerformersFromClaimLines(claimLines, returnChildObj) {
     var uniquePerformerArr = [];
     for (var i = 0; i < Object.keys(claimLines).length; i++) {
 
-        for (var j = 0 ; j < Object.keys(claimLines[i].performer).length; j++) {
+        for (var j = 0; j < Object.keys(claimLines[i].performer).length; j++) {
             var uniqueKey = JSON.stringify(claimLines[i].performer[j]);
             uniquePerformerObj[uniqueKey] = claimLines[i].performer[j];
         }


### PR DESCRIPTION
*Made a bad assumption on how object strings are generated, performers in part d were not correctly stored.
