### PR TITLE
NullFlavor

### DIFF
--- a/lib/parser/common/cleanup.js
+++ b/lib/parser/common/cleanup.js
@@ -96,10 +96,10 @@ cleanup.augmentConcept = function () {
         if (this.js.nullFlavor === "UNK") {
             this.js.code = "";
             delete this.js.nullFlavor;
+        } else {
+            this.js = null;
             return;
         }
-        this.js = null;
-        return;
     }
 
     if (this.js.system) {

--- a/lib/parser/common/cleanup.js
+++ b/lib/parser/common/cleanup.js
@@ -93,6 +93,11 @@ cleanup.augmentConcept = function () {
     }
 
     if (common.exists(this.js.nullFlavor) && !this.js.original_text) {
+        if (this.js.nullFlavor === "UNK") {
+            this.js.code = "";
+            delete this.js.nullFlavor;
+            return;
+        }
         this.js = null;
         return;
     }

--- a/lib/parser/common/cleanup.js
+++ b/lib/parser/common/cleanup.js
@@ -92,15 +92,16 @@ cleanup.augmentConcept = function () {
         this.js = {};
     }
 
-    if (common.exists(this.js.nullFlavor) && !this.js.original_text) {
-        if (this.js.nullFlavor === "UNK") {
+    if (common.exists(this.js.nullFlavor)) {
+        if (this.js.nullFlavor === "UNK" ||
+            (this.js.nullFlavor === "NA" && this.js.translations)) {
             this.js.code = "";
             delete this.js.nullFlavor;
-        } else {
+        } else if (!this.js.original_text) {
             this.js = null;
             return;
         }
-    }
+    };
 
     if (this.js.system) {
         var cs = css.find(this.js.system);

--- a/lib/parser/common/cleanup.js
+++ b/lib/parser/common/cleanup.js
@@ -101,7 +101,7 @@ cleanup.augmentConcept = function () {
             this.js = null;
             return;
         }
-    };
+    }
 
     if (this.js.system) {
         var cs = css.find(this.js.system);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blue-button",
-  "version": "1.8.0-beta.7",
+  "version": "1.8.0-beta.8",
   "description": "Blue Button (CCDA, C32, CMS) to JSON Parser.",
   "main": "./index.js",
   "directories": {


### PR DESCRIPTION
allow translation info to be available, still place empty string in
code, in this case for nullFlavor===“NA”

this commit refactors the logic from the past three nullFlavor-related
commits, making it more readable (I hope)