### PR TITLE
Update demographics.js

### DIFF
--- a/lib/parser/c32/demographics.js
+++ b/lib/parser/c32/demographics.js
@@ -34,7 +34,7 @@ exports.patient = component.define("Patient")
         ["race", "0..1", "h:patient/h:raceCode", shared.ConceptDescriptor],
         ["ethnicity", "0..1", "h:patient/h:ethnicGroupCode", shared.ConceptDescriptor],
         ["languages", "0..*", "h:patient/h:languageCommunication", LanguageCommunication],
-        ["religion", "0..1", "h:patient/h:religiousAffiliationCode/@code", shared.ConceptDescriptor],
+        ["religion", "0..1", "h:patient/h:religiousAffiliationCode", shared.ConceptDescriptor],
         ["birthplace", "0..1", "h:patient/h:birthplace/h:place/h:addr", shared.Address],
         ["guardians", "0..*", "h:patient/h:guardian", Guardian]
     ]);


### PR DESCRIPTION
path for religion was pointing to an xml attribute (@value instead of node), which does not match shared.ConceptDescriptor type. This was causing an error when parsing a valid C32 CCD.